### PR TITLE
Fix build and remove V1 plugin api

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,6 +31,15 @@ android {
         minSdkVersion 21
     }
 
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_1_8
+    }
+
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }

--- a/android/src/main/kotlin/com/example/native_imaging/NativeImagingPlugin.kt
+++ b/android/src/main/kotlin/com/example/native_imaging/NativeImagingPlugin.kt
@@ -3,26 +3,11 @@ package com.example.native_imaging
 import androidx.annotation.NonNull;
 
 import io.flutter.embedding.engine.plugins.FlutterPlugin
-import io.flutter.plugin.common.PluginRegistry.Registrar
+
 
 /** NativeImagingPlugin */
 public class NativeImagingPlugin: FlutterPlugin {
   override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
-  }
-
-  // This static function is optional and equivalent to onAttachedToEngine. It supports the old
-  // pre-Flutter-1.12 Android projects. You are encouraged to continue supporting
-  // plugin registration via this function while apps migrate to use the new Android APIs
-  // post-flutter-1.12 via https://flutter.dev/go/android-project-migration.
-  //
-  // It is encouraged to share logic between onAttachedToEngine and registerWith to keep
-  // them functionally equivalent. Only one of onAttachedToEngine or registerWith will be called
-  // depending on the user's project. onAttachedToEngine or registerWith must both be defined
-  // in the same class.
-  companion object {
-    @JvmStatic
-    fun registerWith(registrar: Registrar) {
-    }
   }
 
   override fun onDetachedFromEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {


### PR DESCRIPTION
Fix:
- https://github.com/famedly/dart_native_imaging/issues/11
- removal of V1 plugin api https://github.com/flutter/engine/pull/51229