### PR TITLE
fix: Correct an off-by-one-error in `lanczos_filter`

### DIFF
--- a/ios/src/Resample.c
+++ b/ios/src/Resample.c
@@ -74,7 +74,7 @@ static inline double sinc_filter(double x)
 static inline double lanczos_filter(double x)
 {
     /* truncated sinc */
-    if (-3.0 <= x && x < 3.0) {
+    if (-3.0 < x && x < 3.0) {
         return sinc_filter(x) * sinc_filter(x/3);
     }
     return 0.0;


### PR DESCRIPTION
I guess that this does practically not matter, but the function is limited asymmetrically now (which seems incorrect to me) and it does neither match what is currently written for this form of the function on [Wikipedia](https://en.wikipedia.org/wiki/Lanczos_resampling#Lanczos_kernel) nor the code in [`image-rs`](https://docs.rs/image/latest/src/image/imageops/sample.rs.html#148-166).